### PR TITLE
Remove Redundant Shortcut Key Definitions and change Zone move Down t…

### DIFF
--- a/DMR/ChannelForm.cs
+++ b/DMR/ChannelForm.cs
@@ -3637,12 +3637,10 @@ namespace DMR
 			this.tsmiLast.Size = new Size(159, 22);
 			this.tsmiLast.Text = "Last";
 			this.tsmiAdd.Name = "tsmiAdd";
-			this.tsmiAdd.ShortcutKeys = (Keys)131137;
 			this.tsmiAdd.Size = new Size(159, 22);
 			this.tsmiAdd.Text = "Add";
 			this.tsmiAdd.Click += this.tsmiAdd_Click;
 			this.tsmiDel.Name = "tsmiDel";
-			this.tsmiDel.ShortcutKeys = (Keys)131140;
 			this.tsmiDel.Size = new Size(159, 22);
 			this.tsmiDel.Text = "Delete";
 			this.tsmiDel.Click += this.tsmiDel_Click;

--- a/DMR/MainForm.cs
+++ b/DMR/MainForm.cs
@@ -670,7 +670,7 @@ namespace DMR
 			this.tsmiMoveUp.Click += this.tsmiMoveUp_Click;
 
 			this.tsmiMoveDown.Name = "tsmiMoveDown";
-			this.tsmiMoveDown.ShortcutKeys = (Keys)131150;
+			this.tsmiMoveDown.ShortcutKeys = (Keys)131140;
 			this.tsmiMoveDown.Size = new Size(158, 22);
 			this.tsmiMoveDown.Text = "Move down";
 			this.tsmiMoveDown.Click += this.tsmiMoveDown_Click;

--- a/DMR/VfoForm.cs
+++ b/DMR/VfoForm.cs
@@ -2255,11 +2255,9 @@ namespace DMR
 			this.tsmiLast.Size = new Size(159, 22);
 			this.tsmiLast.Text = "Last";
 			this.tsmiAdd.Name = "tsmiAdd";
-			this.tsmiAdd.ShortcutKeys = (Keys)131137;
 			this.tsmiAdd.Size = new Size(159, 22);
 			this.tsmiAdd.Text = "Add";
 			this.tsmiDel.Name = "tsmiDel";
-			this.tsmiDel.ShortcutKeys = (Keys)131140;
 			this.tsmiDel.Size = new Size(159, 22);
 			this.tsmiDel.Text = "Delete";
 			this.pnlChannel.AutoScroll = true;

--- a/DMR/ZoneForm.cs
+++ b/DMR/ZoneForm.cs
@@ -1025,12 +1025,10 @@ namespace DMR
 			this.tsmiLast.Text = "Last";
 			this.tsmiLast.Click += this.tsmiLast_Click;
 			this.tsmiAdd.Name = "tsmiAdd";
-			this.tsmiAdd.ShortcutKeys = (Keys)131137;
 			this.tsmiAdd.Size = new Size(159, 22);
 			this.tsmiAdd.Text = "Add";
 			this.tsmiAdd.Click += this.tsmiAdd_Click;
 			this.tsmiDel.Name = "tsmiDel";
-			this.tsmiDel.ShortcutKeys = (Keys)131140;
 			this.tsmiDel.Size = new Size(159, 22);
 			this.tsmiDel.Text = "Delete";
 			this.tsmiDel.Click += this.tsmiDel_Click;


### PR DESCRIPTION
…o be Control D

Channelform,Zoneform, and VFOForm have redundant definitions for shortcut keys that are not used and cause crashes if used at the wrong time. Removing these prevents the crashes.
This allows Zone Move down to be alocated to Control D .