### PR TITLE
Correct another bug reported on Facebook. Only first 256 contacts can…

### DIFF
--- a/DMR/ChannelForm.cs
+++ b/DMR/ChannelForm.cs
@@ -841,7 +841,7 @@ namespace DMR
 				{
 					if (value <= ContactForm.data.Count)
 					{
-						this.contact = (byte)value;
+						this.contact = (ushort)value;
 					}
 				}
 			}


### PR DESCRIPTION
… be selected in a channel.

Same error as scanlists.  Using Byte instead of Ushort.