### PR TITLE
Fixed issue with Shortcut Key sometimes not working

### DIFF
--- a/DMR/MainForm.cs
+++ b/DMR/MainForm.cs
@@ -1841,6 +1841,7 @@ namespace DMR
 						ToolStripMenuItem toolStripMenuItem = this.method_10(treeNodeItem.Cms.Items, keys);
 						if (toolStripMenuItem != null)
 						{
+							toolStripMenuItem.Visible = true;
 							toolStripMenuItem.PerformClick();
 						}
 					}

--- a/DMR/MainForm.cs
+++ b/DMR/MainForm.cs
@@ -1841,7 +1841,32 @@ namespace DMR
 						ToolStripMenuItem toolStripMenuItem = this.method_10(treeNodeItem.Cms.Items, keys);
 						if (toolStripMenuItem != null)
 						{
-							toolStripMenuItem.Visible = true;
+							switch (treeNodeItem.Type.Name)
+							{
+								case "ZoneForm":
+									if (selectedNode.Index == selectedNode.Parent.Nodes.Count - 1)
+									{
+										this.tsmiMoveDown.Visible = false;
+									}
+									else
+									{
+										this.tsmiMoveDown.Visible = true;
+									}
+									if (selectedNode.Index == 0)
+									{
+										this.tsmiMoveUp.Visible = false;
+									}
+									else
+									{
+										this.tsmiMoveUp.Visible = true;
+									}
+									break;
+								case "ChannelForm":
+								default:
+									this.tsmiMoveDown.Visible = false;
+									this.tsmiMoveUp.Visible = false;
+									break;
+							}
 							toolStripMenuItem.PerformClick();
 						}
 					}


### PR DESCRIPTION
Shortcut keys for Move Up and Move Down Sometimes didn't work. 
Toolstrip item was sometimes not set to visible. causing Click() event to fail.