### PR TITLE
Auto set the ID prefix from the Radio ID.

### DIFF
--- a/DMR/DownloadContactsForm.cs
+++ b/DMR/DownloadContactsForm.cs
@@ -17,6 +17,7 @@ namespace DMR
 		public DownloadContactsForm()
 		{
 			InitializeComponent();
+			this.txtIDStart.Text = (int.Parse(GeneralSetForm.data.RadioId) / 10000).ToString();
 		}
 
 		private bool addPrivateContact(string id,string callsignAndName)


### PR DESCRIPTION
Set the Contacts download ID Prefix from the radio ID on the General settings page. 